### PR TITLE
Unify C function declaration representation. Simplify and deduplicate…

### DIFF
--- a/BindingsGenerator.py
+++ b/BindingsGenerator.py
@@ -39,6 +39,34 @@ class BindingsGenerator:
     def __init__(self, args):
         self.args = args
 
+    def generate_bindings(self):
+        """
+        Generates bindings and wrapper for each source file found at path given in arguments
+        and builds wheel out of created package
+        """
+        path = self.args.files_path[0]
+        verbosity = self.args.verbose
+
+        headers = get_header_files(path)
+        sources = get_source_files(path)
+
+        if verbosity:
+            print(f'Copying needed files to destination directory')
+
+        self._copy_needed_files_to_output_dir(headers)
+        self._copy_needed_files_to_output_dir(sources)
+
+        pairs, lone_sources = _get_pairs_and_remainder(headers, sources)
+
+        self._generate_bindings_for_pairs(pairs)
+        self._generate_bindings_for_remainder(lone_sources)
+
+        if verbosity:
+            print('Cleaning up output dir before wheel generation')
+        # Cleaning up a directory causes imports to fail in some test cases under linux
+        # self.cleanup_output_dir()
+        WheelGenerator('.', os.path.basename(path)).generate_wheel()
+
     def _generate_bindings_for_pairs(self, pairs):
         """Generates bindings and wrapper for each pair of source and header files"""
 
@@ -62,7 +90,6 @@ class BindingsGenerator:
                                   include_dirs=self.args.include, libraries=self.args.library,
                                   library_dirs=self.args.lib_dir)
             ffibuilder.compile(verbose=verbosity)
-
             build_wrapper_for_header(name, header)
 
     def _generate_bindings_for_remainder(self, sources):
@@ -80,51 +107,23 @@ class BindingsGenerator:
             if verbosity:
                 print(f'Compiling and creating bindings for {name}')
 
-            declaration_data_list = source.get_declarations()
+            declarations = source.get_declarations()
             ffibuilder = FFI()
-            ffibuilder.cdef(' '.join([x.declaration for x in declaration_data_list]))
+            ffibuilder.cdef(' '.join([x.declaration_string for x in declarations]))
             ffibuilder.set_source('_'+name, '\n'.join(source.includes), sources=[source.filepath],
-                              include_dirs=self.args.include, libraries=self.args.library,
-                              library_dirs=self.args.lib_dir)
+                                  include_dirs=self.args.include, libraries=self.args.library,
+                                  library_dirs=self.args.lib_dir)
             ffibuilder.compile(verbose=verbosity)
-            build_wrapper_for_declarations(name, declaration_data_list)
+            build_wrapper_for_declarations(name, declarations)
 
-    def generate_bindings(self):
-        """
-        Generates bindings and wrapper for each source file found at path given in arguments
-        and builds wheel out of created package
-        """
-        path = self.args.files_path[0]
-        verbosity = self.args.verbose
-
-        headers = get_header_files(path)
-        sources = get_source_files(path)
-
-        if verbosity:
-            print(f'Copying needed files to destination directory')
-
-        self.copy_needed_files_to_output_dir(headers)
-        self.copy_needed_files_to_output_dir(sources)
-
-        pairs, lone_sources = _get_pairs_and_remainder(headers, sources)
-
-        self._generate_bindings_for_pairs(pairs)
-        self._generate_bindings_for_remainder(lone_sources)
-
-        if verbosity:
-            print('Cleaning up output dir before wheel generation')
-        # Cleaning up a directory causes imports to fail in some test cases under linux
-        # self.cleanup_output_dir()
-        WheelGenerator('.', os.path.basename(path)).generate_wheel()
-
-    def copy_needed_files_to_output_dir(self, files):
+    def _copy_needed_files_to_output_dir(self, files):
         """Copies all header or source files to output directory given in arguments"""
 
         for file in files:
             if not os.path.isfile('./' + file.filepath.name):
                 shutil.copy2(str(file.filepath), '.')
 
-    def cleanup_output_dir(self):
+    def _cleanup_output_dir(self):
         """Cleans output directory leaving only .pyd and .py files"""
 
         for (root, dirs, files) in os.walk(self.args.dest, topdown=False):

--- a/BindingsGenerator.py
+++ b/BindingsGenerator.py
@@ -1,6 +1,6 @@
 from HeaderFile import get_header_files
 from SourceFile import get_source_files
-from WrapperBuilder import build_wrapper
+from WrapperBuilder import build_wrapper_for_header, build_wrapper_for_declarations
 from WheelGenerator import WheelGenerator
 from cffi import FFI
 import os
@@ -56,12 +56,13 @@ class BindingsGenerator:
                 print(f'Compiling and creating bindings for {name}')
 
             ffibuilder = FFI()
-            ffibuilder.cdef(header.declarations)
+            all_declaration_strings = ' '.join(decl.declaration_string for decl in header.declarations)
+            ffibuilder.cdef(all_declaration_strings)
             ffibuilder.set_source('_' + name, '\n'.join(source.includes), sources=[source.filepath],
                                   include_dirs=self.args.include, libraries=self.args.library,
                                   library_dirs=self.args.lib_dir)
             ffibuilder.compile(verbose=verbosity)
-            build_wrapper(name, header.declaration_data_list)
+            build_wrapper_for_header(name, header)
 
     def _generate_bindings_for_remainder(self, sources):
         """Generates bindings and wrapper the remainder of source files"""
@@ -85,7 +86,7 @@ class BindingsGenerator:
                               include_dirs=self.args.include, libraries=self.args.library,
                               library_dirs=self.args.lib_dir)
             ffibuilder.compile(verbose=verbosity)
-            build_wrapper(name, declaration_data_list)
+            build_wrapper_for_declarations(name, declaration_data_list)
 
     def generate_bindings(self):
         """

--- a/BindingsGenerator.py
+++ b/BindingsGenerator.py
@@ -62,6 +62,7 @@ class BindingsGenerator:
                                   include_dirs=self.args.include, libraries=self.args.library,
                                   library_dirs=self.args.lib_dir)
             ffibuilder.compile(verbose=verbosity)
+
             build_wrapper_for_header(name, header)
 
     def _generate_bindings_for_remainder(self, sources):

--- a/DoxygenParser.py
+++ b/DoxygenParser.py
@@ -5,20 +5,54 @@ from FunctionParameterTraits import *
 
 class DoxygenParser:
     """
-    Get metadata about a function from doxygen comment
+    Class used to retrieve information about parameters from doxygen comment
+
+    Attributes
+    ----------
+    doxygen : str
+        Single doxygen comment
+    metadata : DoxygenFunctionMetadata
+        Metadata about parameters parsed inside the class
     """
+
     REGEX_IN_PARAM_NAME = r'@param\[in\][\s]*([a-zA-Z_][a-zA-Z0-9_]*)'
+    """ REGEX_IN_PARAM_NAME 
+        Regex used to retrieve IN parameter name from doxygen comment line
+        @param\[in\]  <-- indicates IN parameter
+        [s]* <-- any number of whitespace characters
+        ([a-zA-Z_][a-zA-Z0-9_]*) <-- parameter name (starts with a character, not a number)
+        For example:        
+        '* @param[in]   in_order   sample array (array of size n)'
+        retrieves string 'in_order'
+    """
     REGEX_OUT_PARAM_NAME = r'@param\[out\][\s]*([a-zA-Z_][a-zA-Z0-9_]*)'
+    """ REGEX_OUT_PARAM_NAME 
+        Regex used to retrieve OUT parameter name from doxygen comment line
+        @param\[out\]  <-- indicates OUT parameter
+        The rest - just like in REGEX_IN_PARAM_NAME
+    """
     REGEX_ARRAY_SIZE = r'\(array of size ([A-Za-z0-9])\)'
+    """ REGEX_ARRAY_SIZE 
+        Regex used to retrieve size of an array
+        For example:        
+        '* @param[in]   in_order   sample array (array of size n)'
+        retrieves string 'n'
+    """
 
     def __init__(self, doxygen):
         self.doxygen = doxygen
         self.metadata = self.parse()
 
     def get_parameter(self, name):
+        """ Returns a parameter from a list for a given parameter name """
         return self.metadata.get_parameter(name)
 
     def parse(self):
+        """ Executes parsing of a doxygen comment (retrieves information about parameters)
+            -parameter type (IN/OUT)
+            -whether or not a parameter is an arry
+                -size of an array
+        """
         function_parameters = self.get_function_parameters(self.doxygen)
         return DoxygenFunctionMetadata(function_parameters)
 
@@ -76,7 +110,16 @@ class DoxygenParser:
 
 
 class DoxygenFunctionMetadata:
+    """
+    Class used to represent metadata about a certain function
+    It provides methods for accessing descriptions of function's parameters
 
+    Attributes
+    ----------
+    parameters : list
+        List of DoxygenFunctionParameters - every element
+        in a list contains description of a single parameter, that was read while parsing
+    """
     def __init__(self, parameters):
         self.parameters = parameters
 
@@ -103,13 +146,31 @@ class DoxygenFunctionMetadata:
 
 
 class DoxygenFunctionParameter:
+    """
+    Class used to represent a function parameter - it contains information that
+    was gathered during the parsing of a doxygen comment
 
+    Attributes
+    ----------
+    name: str
+        Name of a parameter
+    param_type: ParameterType
+        Type of a parameter. It can be IN or OUT
+    """
     def __init__(self, name, param_type: ParameterType):
         self.name = name
         self.param_type = param_type
 
 
 class DoxygenFunctionArrayParameter(DoxygenFunctionParameter):
+    """
+    Class used to represent a function parameter that is an array
+
+    Attributes
+    ----------
+    size:
+        Size of an array (int or str)
+    """
 
     def __init__(self, name, param_type: ParameterType, size):
         super().__init__(name, param_type)

--- a/Function.py
+++ b/Function.py
@@ -1,12 +1,14 @@
 from DoxygenParser import *
 from FunctionParameterTraits import *
 
+
 def get_c_type_for_type(t):
     for ct in CType:
         if ct.value == t:
             return ct
 
     return None
+
 
 class FunctionParameter:
 
@@ -23,12 +25,14 @@ class FunctionParameter:
     def __str__(self):
         return self.name + (':' + self.struct if self.struct else '')
 
+
 class FunctionReturn:
 
     def __init__(self, t):
         self.type = t
         self.c_type = get_c_type_for_type(t)
         self.is_void = t == 'void'
+
 
 class FunctionDeclaration:
 
@@ -40,15 +44,16 @@ class FunctionDeclaration:
         self.returns = FunctionReturn(function['rtnType'])
 
         if self.doxygen:
-            self.imbue_with_doxygen(doxygen)
+            self.imbue_with_doxygen(self.doxygen)
 
     def imbue_with_doxygen(self, doxygen):
         meta = DoxygenParser(doxygen)
-        param = meta.get_parameter(self.name)
-        if isinstance(param, DoxygenFunctionArrayParameter):
-            self.is_array = True
-            self.sizes = (param.size,)
-        else:
-            self.is_array = False
+        for parameter in self.parameters:
+            doxygen_function_param = meta.get_parameter(parameter.name)
+            if isinstance(doxygen_function_param, DoxygenFunctionArrayParameter):
+                parameter.is_array = True
+                parameter.sizes = (doxygen_function_param.size,)
+            else:
+                parameter.is_array = False
 
-        self.is_out = (param.param_type == ParameterType.OUT)
+            parameter.is_out = (doxygen_function_param.param_type == ParameterType.OUT)

--- a/Function.py
+++ b/Function.py
@@ -1,8 +1,12 @@
-from DoxygenParser import *
-from FunctionParameterTraits import *
+from DoxygenParser import DoxygenParser, DoxygenFunctionArrayParameter
+from FunctionParameterTraits import ParameterType, CType
 
 
 def get_c_type_for_type(t):
+    """
+    Returns CType object for given type,
+    None if no CType object with this type was found
+    """
     for ct in CType:
         if ct.value == t:
             return ct
@@ -11,6 +15,29 @@ def get_c_type_for_type(t):
 
 
 class FunctionParameter:
+    """
+    Class representing single function parameter
+
+    Attributes
+    ----------
+    name : str
+        Parameter name
+    type : str
+        Parameter type
+    c_type : CType
+        CType enum for type attribute
+    is_array : bool
+        True if parameter is array
+    sizes : tuple
+        Sizes of array, default (None,)
+    is_const : bool
+        True if parameter is constant
+    is_out : bool
+        True if parameter is of ParameterType OUT,
+        default True if parameter is array and not constant
+    struct : str
+        Python object type used to hold this parameter in wrapper
+    """
 
     def __init__(self, param):
         self.name = param['name']
@@ -27,6 +54,18 @@ class FunctionParameter:
 
 
 class FunctionReturn:
+    """
+    Class for holding return info of function
+
+    Attributes
+    ----------
+    type : str
+        Return type string
+    c_type : CType
+        CType enum for type attribute
+    is_void : bool
+        True if return type is void
+    """
 
     def __init__(self, t):
         self.type = t
@@ -35,6 +74,22 @@ class FunctionReturn:
 
 
 class FunctionDeclaration:
+    """
+    Class representing function declaration
+
+    Attributes
+    ----------
+    doxygen : str
+        Doxygen comment string if exists, None otherwise
+    name : str
+        Function name string
+    declaration_string : str
+        String representation of whole declaration
+    parameters : list
+        List of FunctionParameter objects
+    returns : FunctionReturn
+        FunctionReturn object
+    """
 
     def __init__(self, function):
         self.doxygen = function['doxygen'] if 'doxygen' in function.keys() else None
@@ -47,9 +102,10 @@ class FunctionDeclaration:
             self.imbue_with_doxygen(self.doxygen)
 
     def imbue_with_doxygen(self, doxygen):
-        meta = DoxygenParser(doxygen)
+        """Parses doxygen comment and fills attributes with relevant info"""
+        parser = DoxygenParser(doxygen)
         for parameter in self.parameters:
-            doxygen_function_param = meta.get_parameter(parameter.name)
+            doxygen_function_param = parser.get_parameter(parameter.name)
             if isinstance(doxygen_function_param, DoxygenFunctionArrayParameter):
                 parameter.is_array = True
                 parameter.sizes = (doxygen_function_param.size,)

--- a/Function.py
+++ b/Function.py
@@ -16,7 +16,8 @@ class FunctionParameter:
         self.c_type = get_c_type_for_type(self.type)
         self.is_array = param['array'] != 0 or param['pointer'] != 0
         self.sizes = (None,)
-        self.is_out = self.is_array
+        self.is_const = param['constant'] != 0
+        self.is_out = self.is_array and not self.is_const
         self.struct = None
 
     def __str__(self):

--- a/Function.py
+++ b/Function.py
@@ -1,0 +1,53 @@
+from DoxygenParser import *
+from FunctionParameterTraits import *
+
+def get_c_type_for_type(t):
+    for ct in CType:
+        if ct.value == t:
+            return ct
+
+    return None
+
+class FunctionParameter:
+
+    def __init__(self, param):
+        self.name = param['name']
+        self.type = param['type']
+        self.c_type = get_c_type_for_type(self.type)
+        self.is_array = param['array'] != 0 or param['pointer'] != 0
+        self.sizes = (None,)
+        self.is_out = self.is_array
+        self.struct = None
+
+    def __str__(self):
+        return self.name + (':' + self.struct if self.struct else '')
+
+class FunctionReturn:
+
+    def __init__(self, t):
+        self.type = t
+        self.c_type = get_c_type_for_type(t)
+        self.is_void = t == 'void'
+
+class FunctionDeclaration:
+
+    def __init__(self, function):
+        self.doxygen = function['doxygen'] if 'doxygen' in function.keys() else None
+        self.name = function['name']
+        self.declaration_string = function['debug']
+        self.parameters = [FunctionParameter(param) for param in function['parameters']]
+        self.returns = FunctionReturn(function['rtnType'])
+
+        if self.doxygen:
+            self.imbue_with_doxygen(doxygen)
+
+    def imbue_with_doxygen(self, doxygen):
+        meta = DoxygenParser(doxygen)
+        param = meta.get_parameter(self.name)
+        if isinstance(param, DoxygenFunctionArrayParameter):
+            self.is_array = True
+            self.sizes = (param.size,)
+        else:
+            self.is_array = False
+
+        self.is_out = (param.param_type == ParameterType.OUT)

--- a/FunctionParameterTraits.py
+++ b/FunctionParameterTraits.py
@@ -15,9 +15,9 @@ class CType(Enum):
     DOUBLE_POINTER = 'double *'
 
     def get_ffi_string_def(self):
-        if self.name == CType.INT or self.name == self.INT_POINTER.name:
+        if self.name == self.INT.name or self.name == self.INT_POINTER.name:
             return 'int'
-        elif self.name == CType.FLOAT or self.name == self.FLOAT_POINTER.name:
+        elif self.name == self.FLOAT.name or self.name == self.FLOAT_POINTER.name:
             return 'float'
-        elif self.name == CType.DOUBLE or self.name == self.DOUBLE_POINTER.name:
+        elif self.name == self.DOUBLE.name or self.name == self.DOUBLE_POINTER.name:
             return 'double'

--- a/FunctionParameterTraits.py
+++ b/FunctionParameterTraits.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+class ParameterType(Enum):
+    IN = 'in'
+    OUT = 'out'
+
+
+class CType(Enum):
+    INT = 'int'
+    FLOAT = 'float'
+    DOUBLE = 'double'

--- a/FunctionParameterTraits.py
+++ b/FunctionParameterTraits.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+
 class ParameterType(Enum):
     IN = 'in'
     OUT = 'out'
@@ -7,5 +8,16 @@ class ParameterType(Enum):
 
 class CType(Enum):
     INT = 'int'
+    INT_POINTER = 'int *'
     FLOAT = 'float'
+    FLOAT_POINTER = 'float *'
     DOUBLE = 'double'
+    DOUBLE_POINTER = 'double *'
+
+    def get_ffi_string_def(self):
+        if self.name == CType.INT or self.name == self.INT_POINTER.name:
+            return 'int'
+        elif self.name == CType.FLOAT or self.name == self.FLOAT_POINTER.name:
+            return 'float'
+        elif self.name == CType.DOUBLE or self.name == self.DOUBLE_POINTER.name:
+            return 'double'

--- a/FunctionParameterTraits.py
+++ b/FunctionParameterTraits.py
@@ -2,11 +2,13 @@ from enum import Enum
 
 
 class ParameterType(Enum):
+    """Enum describing doxygen parameter type [in] or [out]"""
     IN = 'in'
     OUT = 'out'
 
 
 class CType(Enum):
+    """Enum describing C language types"""
     INT = 'int'
     INT_POINTER = 'int *'
     FLOAT = 'float'
@@ -15,6 +17,7 @@ class CType(Enum):
     DOUBLE_POINTER = 'double *'
 
     def get_ffi_string_def(self):
+        """Returns type name for memory allocation in cffi"""
         if self.name == self.INT.name or self.name == self.INT_POINTER.name:
             return 'int'
         elif self.name == self.FLOAT.name or self.name == self.FLOAT_POINTER.name:

--- a/HeaderFile.py
+++ b/HeaderFile.py
@@ -1,6 +1,6 @@
 import os
 import pathlib
-from Scrapers import *
+from Scrapers import get_function_declarations, get_includes
 
 
 class HeaderFile:
@@ -13,10 +13,8 @@ class HeaderFile:
         Path object pointing to header file
     includes : list
         List of include directives strings scraped from the header
-    declarations : str
-        String of all declarations scraped from header
-    declaration_data_list : list
-        List of DeclarationData objects
+    declarations : list
+        List of FunctionDeclaration objects scraped from header
     """
 
     def __init__(self, h_path):

--- a/HeaderFile.py
+++ b/HeaderFile.py
@@ -1,6 +1,6 @@
 import os
 import pathlib
-from Scrapers import DeclarationsScraper, IncludesScraper
+from Scrapers import *
 
 
 class HeaderFile:
@@ -21,10 +21,8 @@ class HeaderFile:
 
     def __init__(self, h_path):
         self.filepath = h_path
-        declaration_scraper = DeclarationsScraper()
-        self.declarations = declaration_scraper.parse_and_return_decl(self.filepath.as_posix())
-        self.declaration_data_list = declaration_scraper.declaration_data_list
-        self.includes = IncludesScraper().extract_inludes(self.filepath.as_posix())
+        self.declarations = get_function_declarations(self.filepath)
+        self.includes = get_includes(self.filepath)
 
     def __str__(self):
         return 'Header file path: ' + self.filepath.as_posix()

--- a/Scrapers.py
+++ b/Scrapers.py
@@ -1,88 +1,38 @@
 import CppHeaderParser
+from Function import *
 
-
-class DeclarationsScraper:
+def get_function_declarations(filepath):
     """
-    Class used to parse file and return declarations
+    Parses file at given path and fills declarations attribute with FunctionDeclaration objects
 
-    Attributes
+    Parameters
     ----------
-    declaration_data_list : list
-        A list of scraped declarations in DeclarationData object
+    filepath : str
+        Filepath string
     """
+    declarations = []
+    header = CppHeaderParser.CppHeader(filepath)
+    for fun in header.functions:
+        declarations.append(FunctionDeclaration(fun))
 
-    def __init__(self):
-        self.declaration_data_list = []
+    return declarations
 
-    def _parse_file(self, filepath):
-        """Parses file at given path and fills declarations attribute with DeclarationData objects"""
-
-        self.declaration_data_list.clear()
-        file = CppHeaderParser.CppHeader(filepath)
-        for fun in file.functions:
-            doxygen_comment = fun['doxygen'] if 'doxygen' in fun.keys() else ''
-            self.declaration_data_list.append(DeclarationData(doxygen_comment, fun['debug']))
-
-    def parse_and_return_decl(self, filepath):
-        """
-        Parses file using parse_file method and returns joined declarations' strings
-
-        Parameters
-        ----------
-        filepath : str
-            Filepath string
-        Returns
-        -------
-        str
-            String of declarations' strings joined together
-        """
-
-        self._parse_file(filepath)
-        declaration_strings = []
-        for declaration_data in self.declaration_data_list:
-            declaration_strings.append(declaration_data.declaration)
-        return ' '.join(declaration_strings)
-
-
-class IncludesScraper:
+def get_includes(filepath):
     """
-    Class used to parse file and return include directives
-    """
+    Parses file at given path and returns list of include directives
 
-    def extract_inludes(self, path):
-        """
-        Parses file at given path and returns list of include directives
-
-        Parameters
-        ----------
-        path : str
-            Filepath string
-
-        Returns
-        -------
-        includes : list
-            List of include directive strings
-        """
-
-        header = CppHeaderParser.CppHeader(path)
-        includes = []
-        for inc in header.includes:
-            includes.append(f'#include {inc}')
-        return includes
-
-
-class DeclarationData:
-    """
-    Class representing declaration
-
-    Attributes
+    Parameters
     ----------
-    doxygen : str
-        A doxygen string related to declaration
-    declaration : str
-        Declaration string
-    """
+    filepath : str
+        Filepath string
 
-    def __init__(self, doxygen_comment, declaration_string):
-        self.doxygen = doxygen_comment
-        self.declaration = declaration_string.replace('{', ';')
+    Returns
+    -------
+    includes : list
+        List of include directive strings
+    """
+    header = CppHeaderParser.CppHeader(filepath)
+    includes = []
+    for inc in header.includes:
+        includes.append(f'#include {inc}')
+    return includes

--- a/Scrapers.py
+++ b/Scrapers.py
@@ -1,5 +1,5 @@
 import CppHeaderParser
-from Function import *
+from Function import FunctionDeclaration
 
 
 def get_function_declarations(filepath):
@@ -10,6 +10,11 @@ def get_function_declarations(filepath):
     ----------
     filepath : str
         Filepath string
+
+    Returns
+    -------
+    declarations : list
+        List of FunctionDeclaration objects
     """
     declarations = []
     header = CppHeaderParser.CppHeader(filepath)

--- a/Scrapers.py
+++ b/Scrapers.py
@@ -1,6 +1,7 @@
 import CppHeaderParser
 from Function import *
 
+
 def get_function_declarations(filepath):
     """
     Parses file at given path and fills declarations attribute with FunctionDeclaration objects
@@ -16,6 +17,7 @@ def get_function_declarations(filepath):
         declarations.append(FunctionDeclaration(fun))
 
     return declarations
+
 
 def get_includes(filepath):
     """

--- a/SourceFile.py
+++ b/SourceFile.py
@@ -1,6 +1,6 @@
 import os
 import pathlib
-from Scrapers import DeclarationsScraper, IncludesScraper
+from Scrapers import *
 
 
 class SourceFile:
@@ -17,7 +17,7 @@ class SourceFile:
 
     def __init__(self, src_path):
         self.filepath = src_path
-        self.includes = IncludesScraper().extract_inludes(self.filepath.as_posix())
+        self.includes = get_includes(self.filepath)
 
     def __str__(self):
         return 'Source file path: ' + self.filepath.as_posix()

--- a/SourceFile.py
+++ b/SourceFile.py
@@ -1,6 +1,6 @@
 import os
 import pathlib
-from Scrapers import *
+from Scrapers import get_function_declarations, get_includes
 
 
 class SourceFile:
@@ -23,9 +23,8 @@ class SourceFile:
         return 'Source file path: ' + self.filepath.as_posix()
 
     def get_declarations(self):
-        declaration_scraper = DeclarationsScraper()
-        declaration_scraper.parse_and_return_decl(self.filepath.as_posix())
-        return declaration_scraper.declaration_data_list
+        declarations = get_function_declarations(self.filepath)
+        return declarations
 
 
 def get_source_files(dirpath):

--- a/WrapperBuilder.py
+++ b/WrapperBuilder.py
@@ -6,13 +6,13 @@ def get_declaration(declaration):
 
 # TODO: what does this function name mean?
 def _get_rewriter_into_array(name):
-    s = '    for i,v in enumerate(' + name + '):\r'
-    s = s + '        ' + name + '2[i] = ' + name + '[i]\r'
+    s = '    for i,v in enumerate(' + name + '):\n'
+    s = s + '        ' + name + '2[i] = ' + name + '[i]\n'
     return s
 
 def _get_rewriter_into_list(name):
-    s = '    for i,v in enumerate(' + name + '2):\r'
-    s = s + '        ' + name + '[i] = ' + name + '2[i]\r'
+    s = '    for i,v in enumerate(' + name + '2):\n'
+    s = s + '        ' + name + '[i] = ' + name + '2[i]\n'
     return s
 
 # TODO: just appending 2 to the parameter is not safe, there may be collisions
@@ -20,18 +20,18 @@ def _get_rewriter_into_list(name):
 def _build_python_function_wrapper_for_declaration(module_name, declaration):
     s = 'def ' + declaration.name + '('
     s = s + ','.join([x.name for x in declaration.parameters])
-    s = s + '):\r'
+    s = s + '):\n'
 
     for parameter in declaration.parameters:
         if parameter.is_out and parameter.is_array:
             size = str(parameter.sizes[0]) if parameter.sizes[0] else 'len(' + parameter.name + ')'
-            s = s + '    ' + parameter.name + '2 = ffi.new("' + parameter.c_type.value + '[]", ' + size + ')\r'
+            s = s + '    ' + parameter.name + '2 = ffi.new("' + parameter.c_type.value + '[]", ' + size + ')\n'
             s = s + _get_rewriter_into_array(parameter.name)
         else:
-            s = s + '    ' + parameter.name + '2 = ' + parameter.name + '\r'
+            s = s + '    ' + parameter.name + '2 = ' + parameter.name + '\n'
 
     s = s + '    ' + ('ret = ' if not declaration.returns.is_void else '') + '_' + module_name + '.lib.' + \
-        declaration.name + '(' + ','.join([x.name + '2' for x in declaration.parameters]) + ')\r'
+        declaration.name + '(' + ','.join([x.name + '2' for x in declaration.parameters]) + ')\n'
 
     for parameter in declaration.parameters:
         if not parameter.is_out:
@@ -39,12 +39,12 @@ def _build_python_function_wrapper_for_declaration(module_name, declaration):
         if parameter.is_array:
             s = s + _get_rewriter_into_list(parameter.name)
         else:
-            s = s + '    ' + parameter.name + ' = ' + parameter.name + '2\r'
+            s = s + '    ' + parameter.name + ' = ' + parameter.name + '2\n'
 
     if not declaration.returns.is_void:
         s = s + '    return ret'
 
-    return s + '\r\n\n'
+    return s + '\n\n'
 
 def _build_wrapper_for_declaration(header_name, f, declaration):
     s = _build_python_function_wrapper_for_declaration(header_name, declaration)
@@ -56,7 +56,7 @@ def _build_wrapper_for_header(header_name, f, header):
 
 def build_wrapper_for_header(header_name, header):
     with open(header_name + '.py', 'w+') as f:
-        f.write("from . import _" + header_name + "\rfrom cffi import FFI\rffi = FFI()\r\n\n")
+        f.write("from . import _" + source_name + "\nfrom cffi import FFI\nffi = FFI()\n\n")
 
         _build_wrapper_for_header(header_name, f, header)
 

--- a/WrapperBuilder.py
+++ b/WrapperBuilder.py
@@ -1,9 +1,3 @@
-from DoxygenParser import *
-from Function import *
-
-def get_declaration(declaration):
-    return Declaration(declaration)
-
 # TODO: better tool for idendation
 
 # TODO: what does this function name mean?
@@ -13,11 +7,13 @@ def _get_rewriter_into_array(name):
         f'\t\t{name}2[i] = {name}[i]'
     ]
 
+
 def _get_rewriter_into_list(name):
     return [
         f'\tfor i,v in enumerate({name}):',
         f'\t\t{name}[i] = {name}2[i]'
     ]
+
 
 # TODO: just appending 2 to the parameter is not safe, there may be collisions
 #       use more sophisticated mangling, for example prepend/append $
@@ -29,7 +25,7 @@ def _build_python_function_wrapper_for_declaration(module_name, declaration):
     for parameter in declaration.parameters:
         if parameter.is_out and parameter.is_array:
             size = str(parameter.sizes[0]) if parameter.sizes[0] else 'len(' + parameter.name + ')'
-            lines.append(f'\t{parameter.name}2 = ffi.new("{parameter.c_type.value}[]", {size})')
+            lines.append(f'\t{parameter.name}2 = ffi.new("{parameter.c_type.get_ffi_string_def()}[]", {size})')
             lines += _get_rewriter_into_array(parameter.name)
         else:
             lines.append(f'\t{parameter.name}2 = {parameter.name}')
@@ -57,9 +53,11 @@ def _build_python_function_wrapper_for_declaration(module_name, declaration):
 
     return '\n'.join(lines)
 
+
 def _build_wrapper_for_declaration(header_name, f, declaration):
     s = _build_python_function_wrapper_for_declaration(header_name, declaration)
     f.write(s)
+
 
 def _build_wrapper_for_header(header_name, f, header):
     for decl in header.declarations:

--- a/WrapperBuilder.py
+++ b/WrapperBuilder.py
@@ -65,7 +65,7 @@ def _build_wrapper_for_header(header_name, f, header):
 
 def build_wrapper_for_header(header_name, header):
     with open(header_name + '.py', 'w+') as f:
-        f.write("from . import _" + source_name + "\nfrom cffi import FFI\nffi = FFI()\n\n")
+        f.write("from . import _" + header_name + "\nfrom cffi import FFI\nffi = FFI()\n\n")
 
         _build_wrapper_for_header(header_name, f, header)
 

--- a/WrapperBuilder.py
+++ b/WrapperBuilder.py
@@ -1,6 +1,24 @@
 unique_identifier_suffix = '__internal'
 
-# TODO: better tool for idendation
+# TODO: better tool for indendation
+
+
+def build_wrapper_for_header(header_name, header):
+    """Creates wrapper file for given HeaderFile"""
+    with open(header_name + '.py', 'w+') as f:
+        f.write("from . import _" + header_name + "\nfrom cffi import FFI\nffi = FFI()\n\n")
+
+        _build_wrapper_for_header(header_name, f, header)
+
+
+def build_wrapper_for_declarations(header_name, declarations):
+    """Creates wrapper file for given list of FunctionDeclaration objects"""
+    with open(header_name + '.py', 'w+') as f:
+        f.write("from . import _" + header_name + "\rfrom cffi import FFI\rffi = FFI()\r\n\n")
+
+        for decl in declarations:
+            _build_wrapper_for_declaration(header_name, f, decl)
+
 
 def _build_array_copy(name, _from, to):
     return [
@@ -54,16 +72,3 @@ def _build_wrapper_for_declaration(header_name, f, declaration):
 def _build_wrapper_for_header(header_name, f, header):
     for decl in header.declarations:
         _build_wrapper_for_declaration(header_name, f, decl)
-
-def build_wrapper_for_header(header_name, header):
-    with open(header_name + '.py', 'w+') as f:
-        f.write("from . import _" + header_name + "\nfrom cffi import FFI\nffi = FFI()\n\n")
-
-        _build_wrapper_for_header(header_name, f, header)
-
-def build_wrapper_for_declarations(header_name, declarations):
-    with open(header_name + '.py', 'w+') as f:
-        f.write("from . import _" + header_name + "\rfrom cffi import FFI\rffi = FFI()\r\n\n")
-
-        for decl in declarations:
-            _build_wrapper_for_declaration(header_name, f, decl)

--- a/test_library/test.c
+++ b/test_library/test.c
@@ -6,7 +6,7 @@ void func(double out[]){
     }
 }
 
-double sum(double a, double out[]){
+double sum(double a, const double out[]){
     double s = a;
 	for(int i=0;i<5;i++){
         s += out[i];

--- a/test_library/test.h
+++ b/test_library/test.h
@@ -1,2 +1,2 @@
 void func(double out[]);
-double sum(double a, double out[]);
+double sum(double a, const double out[]);

--- a/tests/arrays/test_ArraysFunctions.py
+++ b/tests/arrays/test_ArraysFunctions.py
@@ -23,7 +23,7 @@ class SimpleFunctionsTest(unittest.TestCase):
     def test_generate_bindings_to_function_with_array(self):
 
         from tests.arrays.generated.sources import arraytest
-        a = []
+        a = [0]*5
         arraytest.func(a)
         self.assertEqual(a, [0.0, 1.0, 2.0, 3.0, 4.0])
 

--- a/tests/arrays/test_ArraysFunctions.py
+++ b/tests/arrays/test_ArraysFunctions.py
@@ -30,7 +30,7 @@ class SimpleFunctionsTest(unittest.TestCase):
     def test_generate_bindings_to_function_with_array_sum(self):
 
         from tests.arrays.generated.sources import arraytest
-        a = [2.0, 3.0]
+        a = [2.0, 3.0, 4.0, 5.0, 6.0]
         i = arraytest.sum(4.0, a)
-        self.assertEqual(i, 9.0)
+        self.assertEqual(i, 24.0)
 


### PR DESCRIPTION
Chciałem szybko zrobić #3 i stwierdziłem, że aktualny model będzie nam bardzo przeszkadzał w przyszłości. W związku z tym zamiast traktować funkcje z doxygenem zupełnie inaczej niż te z doxygenem proponuję unifikację modelu. Wcześniej były chyba 3 różne klasy do reprezentacji deklaracji funkcji i jej parameterów, i sporo konwersji między nimi. Kod generowania wrapperów był praktycznie zduplikowany i ciężko było modyfikować oba na raz. HeaderFile posiadał redundante pola i ciężko było wywnioskować jakiej informacji w jakich polach szukać. parameter.struct był używany jako określenie czy jest tablicą, ale zakładam, że docelowe użycie jest inne - trzymajny explicite flage czy to tablica.

Zrobiłem więc:
- jedna klasa do reprezentacji metadanych o funkcji TYLKO z doxygena - czyli aktualnie jedynie czy parameter jest in czy out i ewentualnie array
- jedna klasa do reprezentacji deklaracji funkcji ze wszsytkim co nam potrzebne - tworzona na podstawie informacji z CppHeaderParser. Dodatkowo zbiera informacje z metadanych doxygena jest takowy jest
- jedna klasa do reprezentacji parametru funkcji
- jedna funkcja generująca wrapper do funkcji, którą nie interesuje w ogóle doxygen - to się dzieje wcześniej
- przy okazji wyrzucenie kilku klas na rzecz funkcji - nie potrzebowały stanu
- no i ogarnięci #3 ...

W efekcie mamy dużo prostszy kod.
